### PR TITLE
Potential fix for code scanning alert no. 98: Uncontrolled data used in path expression

### DIFF
--- a/backend/controllers/item.controller.js
+++ b/backend/controllers/item.controller.js
@@ -2,6 +2,7 @@ const { z } = require('zod');
 const Item = require('../models/item.model');
 const cloudinary = require('../config/cloudinary');
 const fs = require('fs').promises;
+const path = require('path');
 const { createItemSchema, updateItemSchema } = require('../schema/item.schema');
 const QRCode = require('qrcode');
 const otpGenerator = require('otp-generator');
@@ -73,7 +74,14 @@ exports.createItem = async (req, res) => {
         console.error('Cloudinary upload error:', cloudinaryError.message);
         return res.status(500).json({ message: 'Failed to upload image to Cloudinary', code: 'CLOUDINARY_ERROR', details: cloudinaryError.message });
       } finally {
-        await fs.unlink(filePath).catch((err) => console.error('Failed to delete temp file:', err));
+        // Only delete files within the upload directory
+        const UPLOAD_DIR = path.resolve(__dirname, '../../uploads'); // adjust as needed
+        const resolvedPath = path.resolve(filePath);
+        if (resolvedPath.startsWith(UPLOAD_DIR)) {
+          await fs.unlink(resolvedPath).catch((err) => console.error('Failed to delete temp file:', err));
+        } else {
+          console.error('Attempted to delete file outside of upload directory:', resolvedPath);
+        }
       }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Swastik007sharma/CampusTrack/security/code-scanning/98](https://github.com/Swastik007sharma/CampusTrack/security/code-scanning/98)

To fix this issue, we need to ensure that the file path used in `fs.unlink` is contained within a safe, expected directory (such as the upload temp directory). This can be done by normalizing the path using `path.resolve`, and then checking that the resolved path starts with the expected upload directory. If the check fails, the file should not be deleted, and an error should be logged. This fix should be applied in the block where `filePath` is used (line 76). We will need to import the `path` module if it is not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
