### PR TITLE
Added dark mode to footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -11,8 +11,10 @@ import {
     Mail
 } from "lucide-react";
 import { Link } from "react-router-dom";
+import { useTheme } from '../context/ThemeContext';
 
 const Footer = () => {
+    const { theme } = useTheme();
     const currentYear = new Date().getFullYear();
 
     const socialLinks = [
@@ -58,14 +60,14 @@ const Footer = () => {
     ];
 
     return (
-        <footer className="bg-white text-gray-800 border-t border-gray-200">
+        <footer className={`${theme === "dark" ? "bg-gray-900 text-gray-100 border-gray-700" : "bg-white text-gray-800 border-gray-200"}`}>
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
                     <div className="lg:col-span-2">
                         <h2 className="text-xl font-bold text-blue-600 mb-3">
                             CampusTrack
                         </h2>
-                        <p className="max-w-md text-sm leading-6 text-gray-600">
+                        <p className={`max-w-md text-sm leading-6 ${theme === "dark" ? "text-gray-300" : "text-gray-600"}`}>
                             CampusTrack is a full-stack web application designed to help students and staff of a college report, find, and manage lost and found items on campus. The system enables seamless tracking of lost belongings, efficient moderation, and easy communication between finders and owners.
                         </p>
                         <div className="flex space-x-4 mt-6">
@@ -75,7 +77,7 @@ const Footer = () => {
                                     href={social.href}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="text-gray-500 hover:text-blue-600 transition-colors duration-200"
+                                    className={`${theme === "dark" ? "text-gray-400" : "text-gray-500"} hover:text-blue-500 transition-colors duration-200`}
                                 >
                                     <social.icon className="w-5 h-5 hover:scale-110 transition-transform duration-200" />
                                 </a>
@@ -85,7 +87,7 @@ const Footer = () => {
 
                     {footerLinks.map((section) => (
                         <div key={section.title}>
-                            <h3 className="font-semibold mb-4 text-sm text-gray-900 uppercase tracking-wide">
+                            <h3 className={`font-semibold mb-4 text-sm uppercase tracking-wide ${theme === "dark" ? "text-gray-100" : "text-gray-900"}`}>
                                 {section.title}
                             </h3>
                             <ul className="space-y-3">
@@ -93,9 +95,9 @@ const Footer = () => {
                                     <li key={link.name}>
                                         <Link
                                             to={link.href}
-                                            className="text-sm flex items-center gap-2 text-gray-700 hover:text-blue-600 transition-colors duration-200"
+                                            className={`text-sm flex items-center gap-2 hover:text-blue-500 transition-colors duration-200 ${theme === "dark" ? "text-gray-300" : "text-gray-700"}`}
                                         >
-                                            <link.icon className="w-4 h-4 text-gray-500 group-hover:text-blue-600 transition-colors duration-200" />
+                                            <link.icon className={`w-4 h-4 transition-colors duration-200 ${theme === "dark" ? "text-gray-400" : "text-gray-500"}`} />
                                             <span>{link.name}</span>
                                         </Link>
                                     </li>
@@ -105,12 +107,12 @@ const Footer = () => {
                     ))}
                 </div>
 
-                <div className="border-t mt-12 pt-6 border-gray-200">
+                <div className={`border-t mt-12 pt-6 ${theme === "dark" ? "border-gray-700" : "border-gray-200"}`}>
                     <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-                        <p className="text-center md:text-left text-xs text-gray-500">
+                        <p className={`text-center md:text-left text-xs ${theme === "dark" ? "text-gray-400" : "text-gray-500"}`}>
                             © {currentYear} CampusTrack. Made with ❤️ All rights reserved.
                         </p>
-                        <div className="flex items-center space-x-4 text-xs text-gray-500">
+                        <div className={`flex items-center space-x-4 text-xs ${theme === "dark" ? "text-gray-400" : "text-gray-500"}`}>
                             <Link to="/privacy-policy" className="hover:text-blue-600 transition-colors">
                                 Privacy Policy
                             </Link>


### PR DESCRIPTION
## Fixes #64 

## Description
This PR fixes the issue where the footer remained in light theme colors while the rest of the UI switched to dark mode. The footer now properly adapts to dark mode styling for visual consistency.

## Screenshots

### Before 
<img width="1365" height="601" alt="478327989-e61ce8ec-dabe-490b-83e0-9c52f6299322" src="https://github.com/user-attachments/assets/5e0f8fc4-8db4-4366-a17a-9a65a258234d" />

### After 
<img width="1365" height="655" alt="Screenshot 2025-08-16 083033" src="https://github.com/user-attachments/assets/3f61114e-caf0-464e-8a15-7561256b9736" />
